### PR TITLE
Revert "Use Tekton v1 API"

### DIFF
--- a/build/tasks/build.yaml
+++ b/build/tasks/build.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ods-pipeline-go-build

--- a/tasks/build.yaml
+++ b/tasks/build.yaml
@@ -1,6 +1,6 @@
 # File is generated; DO NOT EDIT.
 
-apiVersion: tekton.dev/v1
+apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ods-pipeline-go-build


### PR DESCRIPTION
Reverts opendevstack/ods-pipeline-go#2.

This does not work yet with the OpenShift Pipelines operator 1.11.